### PR TITLE
Small tweaks for some things we ran into

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Integration testing for Go using Ginkgo and Gomega!
 
 Install:
 ```bash
-$ go get -d github.com/sclevine/agouti
+$ go get github.com/sclevine/agouti/...
 ```
 To use with PhantomJS (OS X):
 ```bash


### PR DESCRIPTION
- `go get` fails because there are no buildable go files
- outermost `Feature` needs to be assigned to an empty variable
- add missing import to example
- change server url to example.com to make it clearer that it isn't part of agouti
