### PR TITLE
First draft of SwitchTo() and Windows handling.

### DIFF
--- a/core/internal/api/client.go
+++ b/core/internal/api/client.go
@@ -60,6 +60,13 @@ func (c *Client) GetWindow() (types.Window, error) {
 	return &window.Window{ID: windowID, Session: c.Session}, nil
 }
 
+func (c *Client) DeleteWindow() error {
+	if err := c.Session.Execute("window", "DELETE", nil, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (c *Client) GetWindows() ([]types.Window, error) {
 	var windowsID []string
 	if err := c.Session.Execute("window_handles", "GET", nil, &windowsID); err != nil {

--- a/core/internal/api/client.go
+++ b/core/internal/api/client.go
@@ -60,6 +60,19 @@ func (c *Client) GetWindow() (types.Window, error) {
 	return &window.Window{ID: windowID, Session: c.Session}, nil
 }
 
+func (c *Client) GetWindows() ([]types.Window, error) {
+	var windowsID []string
+	if err := c.Session.Execute("window_handles", "GET", nil, &windowsID); err != nil {
+		return nil, err
+	}
+
+	var windows []types.Window
+	for _, windowID := range windowsID {
+		windows = append(windows, &window.Window{ID: windowID, Session: c.Session})
+	}
+	return windows, nil
+}
+
 func (c *Client) SetCookie(cookie interface{}) error {
 	request := struct {
 		Cookie interface{} `json:"cookie"`

--- a/core/internal/api/window/window.go
+++ b/core/internal/api/window/window.go
@@ -1,6 +1,10 @@
 package window
 
-import "github.com/sclevine/agouti/core/internal/types"
+import (
+	"fmt"
+
+	"github.com/sclevine/agouti/core/internal/types"
+)
 
 type Window struct {
 	ID      string
@@ -15,6 +19,31 @@ func (w *Window) SetSize(width, height int) error {
 	}{width, height}
 
 	if err := w.Session.Execute(endpoint, "POST", &request, &struct{}{}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (w *Window) SwitchTo() error {
+	request := struct {
+		Handle string `json:"handle"`
+	}{w.ID}
+	if err := w.Session.Execute("window", "POST", &request, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (w *Window) Close() error {
+	fmt.Println("OK, switching to", w.ID)
+	err := w.SwitchTo()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("OK, Closing now", w.ID)
+	if err := w.Session.Execute("window_handle", "DELETE", nil, nil); err != nil {
+		fmt.Println("OK, failed, here", err)
 		return err
 	}
 	return nil

--- a/core/internal/api/window/window.go
+++ b/core/internal/api/window/window.go
@@ -29,15 +29,3 @@ func (w *Window) SwitchTo() error {
 	}
 	return nil
 }
-
-func (w *Window) Close() error {
-	err := w.SwitchTo()
-	if err != nil {
-		return err
-	}
-
-	if err := w.Session.Execute("window", "DELETE", nil, nil); err != nil {
-		return err
-	}
-	return nil
-}

--- a/core/internal/api/window/window.go
+++ b/core/internal/api/window/window.go
@@ -1,10 +1,6 @@
 package window
 
-import (
-	"fmt"
-
-	"github.com/sclevine/agouti/core/internal/types"
-)
+import "github.com/sclevine/agouti/core/internal/types"
 
 type Window struct {
 	ID      string
@@ -35,15 +31,12 @@ func (w *Window) SwitchTo() error {
 }
 
 func (w *Window) Close() error {
-	fmt.Println("OK, switching to", w.ID)
 	err := w.SwitchTo()
 	if err != nil {
 		return err
 	}
 
-	fmt.Println("OK, Closing now", w.ID)
-	if err := w.Session.Execute("window_handle", "DELETE", nil, nil); err != nil {
-		fmt.Println("OK, failed, here", err)
+	if err := w.Session.Execute("window", "DELETE", nil, nil); err != nil {
 		return err
 	}
 	return nil

--- a/core/internal/page/page.go
+++ b/core/internal/page/page.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sclevine/agouti/core/internal/types"
 	"regexp"
+
+	"github.com/sclevine/agouti/core/internal/types"
 )
 
 type Page struct {
@@ -206,6 +207,25 @@ func (p *Page) SwitchToRootFrame() error {
 
 func (p *Page) Window() (types.Window, error) {
 	return p.Client.GetWindow()
+}
+
+func (p *Page) CloseWindow(newWin types.Window) error {
+	win, err := p.Client.GetWindow()
+	fmt.Printf("HEEEYA %#v", win)
+	if err != nil {
+		return fmt.Errorf("failed to get window: %s", err)
+	}
+
+	if err := newWin.SwitchTo(); err != nil {
+		return fmt.Errorf("failed to switch to window: %s", err)
+	}
+	if err := p.Client.DeleteWindow(); err != nil {
+		return fmt.Errorf("failed to close window: %s", err)
+	}
+	if err := win.SwitchTo(); err != nil {
+		return fmt.Errorf("failed to switch back to original window: %s", err)
+	}
+	return nil
 }
 
 func (p *Page) Windows() ([]types.Window, error) {

--- a/core/internal/page/page.go
+++ b/core/internal/page/page.go
@@ -204,6 +204,18 @@ func (p *Page) SwitchToRootFrame() error {
 	return nil
 }
 
+func (p *Page) Window() (types.Window, error) {
+	return p.Client.GetWindow()
+}
+
+func (p *Page) Windows() ([]types.Window, error) {
+	wins, err := p.Client.GetWindows()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get window handles: %s", err)
+	}
+	return wins, nil
+}
+
 func (p *Page) LogTypes() ([]string, error) {
 	types, err := p.Client.GetLogTypes()
 	if err != nil {

--- a/core/internal/types/client.go
+++ b/core/internal/types/client.go
@@ -4,6 +4,7 @@ type Client interface {
 	DeleteSession() error
 	GetWindow() (Window, error)
 	GetWindows() ([]Window, error)
+	DeleteWindow() error
 	GetScreenshot() ([]byte, error)
 	SetCookie(cookie interface{}) error
 	DeleteCookie(name string) error

--- a/core/internal/types/client.go
+++ b/core/internal/types/client.go
@@ -3,6 +3,7 @@ package types
 type Client interface {
 	DeleteSession() error
 	GetWindow() (Window, error)
+	GetWindows() ([]Window, error)
 	GetScreenshot() ([]byte, error)
 	SetCookie(cookie interface{}) error
 	DeleteCookie(name string) error

--- a/core/internal/types/window.go
+++ b/core/internal/types/window.go
@@ -2,4 +2,6 @@ package types
 
 type Window interface {
 	SetSize(height, width int) error
+	SwitchTo() error
+	Close() error
 }

--- a/core/internal/types/window.go
+++ b/core/internal/types/window.go
@@ -3,5 +3,4 @@ package types
 type Window interface {
 	SetSize(height, width int) error
 	SwitchTo() error
-	Close() error
 }

--- a/core/page.go
+++ b/core/page.go
@@ -88,6 +88,9 @@ type Page interface {
 	// as well.
 	SwitchToRootFrame() error
 
+	// CloseWindow closes an open tab or window
+	CloseWindow(types.Window) error
+
 	// Windows returns a list of Windows handles, so you can SwitchTo() them
 	Windows() ([]types.Window, error)
 

--- a/core/page.go
+++ b/core/page.go
@@ -88,6 +88,9 @@ type Page interface {
 	// as well.
 	SwitchToRootFrame() error
 
+	// Windows returns a list of Windows handles, so you can SwitchTo() them
+	Windows() ([]types.Window, error)
+
 	// ReadLogs returns log messages of the provided log type. For example,
 	// page.ReadLogs("browser") returns browser console logs, such as JavaScript logs
 	// and errors. If the all argument is provided as true, all logs since the session


### PR DESCRIPTION
This PR is for discussions, is untested, just to clarify the API design.

I need to list, close and switch windows.  The WebDrivers specs talk about that (`window_handle` and `window_handles` and `DELETE` to close, etc..).. Capybara also has support for such things.

What would be the best approach to do this ?  Normally, the _window_ related functions would be on the `Session`.. but here we have a `Page` object at hand most of the time. It might add a bit of confusion to talk about pages and windows as different things, so I'm unsure where we can steer this.

I've gone through the `CONTRIBUTIONS.md` file.. anything specific you'd require to merge such a proposition ?

thanks for the great lib btw :)