### PR TITLE
Implemented Windows() to retrieve the open windows.

### DIFF
--- a/core/internal/api/window.go
+++ b/core/internal/api/window.go
@@ -17,3 +17,7 @@ func (w *Window) SetSize(width, height int) error {
 	}
 	return nil
 }
+
+func (w *Window) String() string {
+	return w.ID
+}

--- a/core/internal/page/page.go
+++ b/core/internal/page/page.go
@@ -287,6 +287,18 @@ func (p *Page) WindowCount() (int, error) {
 	return len(windows), nil
 }
 
+func (p *Page) Windows() ([]string, error) {
+	windows, err := p.Client.GetWindows()
+	if err != nil {
+		return nil, fmt.Errorf("failed to find available windows: %s", err)
+	}
+	var out []string
+	for _, win := range windows {
+		out = append(out, win.String())
+	}
+	return out, nil
+}
+
 func (p *Page) LogTypes() ([]string, error) {
 	types, err := p.Client.GetLogTypes()
 	if err != nil {

--- a/core/page.go
+++ b/core/page.go
@@ -89,8 +89,8 @@ type Page interface {
 	// as well.
 	SwitchToRootFrame() error
 
-	// SwitchToWindow switches to the first available window with the provided name
-	// (JavaScript `window.name` attribute).
+	// SwitchToWindow switches to the first available window with the provided handle
+	// (find them with `WindowCount()`).
 	SwitchToWindow(name string) error
 
 	// NextWindow switches to the next available window.
@@ -101,6 +101,9 @@ type Page interface {
 
 	// WindowCount returns the number of available windows.
 	WindowCount() (int, error)
+
+	// GetWindows retrieves the list of open windows.
+	Windows() ([]string, error)
 
 	// ReadLogs returns log messages of the provided log type. For example,
 	// page.ReadLogs("browser") returns browser console logs, such as JavaScript logs


### PR DESCRIPTION
This is needed to close the windows, `window.name` is always empty and WebDriver
doesn't read that I think.

I know tests are missing.. haven't looked at the testing machinery in there.. It works in my app though.

What do you think ?  This way we keep `types.Window` behind the scene.