### PR TITLE
Use SIGTERM instead of SIGINT to kill test driver processes.

### DIFF
--- a/api/internal/service/service.go
+++ b/api/internal/service/service.go
@@ -72,7 +72,7 @@ func (s *Service) Stop() error {
 	if runtime.GOOS == "windows" {
 		err = s.command.Process.Kill()
 	} else {
-		err = s.command.Process.Signal(syscall.SIGINT)
+		err = s.command.Process.Signal(syscall.SIGTERM)
 	}
 	if err != nil {
 		return fmt.Errorf("failed to stop command: %s", err)


### PR DESCRIPTION
First, for background, I develop on Linux and typically use NPM instead of Homebrew to manage dependencies like PhatomJS, Selenium, and ChromeDriver (mostly out of convenience). The NPM packages for these tools install wrapper scripts on the system path and spawn the real driver in a child process. The convention on Linux (and I assume other *nix systems) is to use `SIGTERM` to kill a background process. `SIGINT` is typically used by the shell to kill the entire foreground process group after a keyboard interrupt (so propagating `SIGINT` to children is usually not necessary). See the following for reference:

 + http://man7.org/linux/man-pages/man1/kill.1.html
 + http://www.gnu.org/software/bash/manual/bashref.html#Job-Control-Basics
 + http://man7.org/linux/man-pages/man7/signal.7.html

This convention seems to be followed by the PhantomJS and ChromeDriver wrappers as they propagate `SIGTERM` but not `SIGINT`:

 + https://github.com/Medium/phantomjs/blob/master/bin/phantomjs
 + https://github.com/giggio/node-chromedriver/blob/master/bin/chromedriver

Without this change, I end up with a bunch of orphaned test driver processes after running my test suite.

I struggled to find a good way to create a new test case for this change, but am open to suggestions.