### PR TITLE
Fix typo

### DIFF
--- a/page.go
+++ b/page.go
@@ -403,7 +403,7 @@ func (p *Page) ReadNewLogs(logType string) ([]Log, error) {
 }
 
 // ReadAllLogs returns all log messages of the provided log type. For example,
-// page.ReadLogs("browser") returns browser console logs, such as JavaScript logs
+// page.ReadAllLogs("browser") returns browser console logs, such as JavaScript logs
 // and errors. All logs since the session was created are returned.
 // Valid log types may be obtained using the LogTypes method.
 func (p *Page) ReadAllLogs(logType string) ([]Log, error) {


### PR DESCRIPTION
`ReadLogs` should read `ReadAllLogs`; `ReadLogs` still exists in the `core` package [1] but was not included here when `core` was deprecated in 14fd01f328a.

[1]: https://github.com/sclevine/agouti/blob/7fd203841f2a5b43b675f4c8d05b4668bbae1e53/core/page.go#L111