### PR TITLE
Implemented Debug() call on driver, to enable debugging when running different webdrivers.

### DIFF
--- a/api/internal/mocks/service.go
+++ b/api/internal/mocks/service.go
@@ -42,3 +42,6 @@ func (s *Service) WaitForBoot(timeout time.Duration) error {
 	s.WaitForBootCall.Timeout = timeout
 	return s.WaitForBootCall.Err
 }
+
+func (s *Service) Debug(state bool) {
+}

--- a/api/internal/service/service.go
+++ b/api/internal/service/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -17,6 +18,7 @@ type Service struct {
 	CmdTemplate []string
 	url         string
 	command     *exec.Cmd
+	debug       bool
 }
 
 type addressInfo struct {
@@ -50,6 +52,11 @@ func (s *Service) Start() error {
 	command, err := buildCommand(s.CmdTemplate, address)
 	if err != nil {
 		return fmt.Errorf("failed to parse command: %s", err)
+	}
+
+	if s.debug {
+		command.Stdout = os.Stdout
+		command.Stderr = os.Stderr
 	}
 
 	if err := command.Start(); err != nil {
@@ -130,4 +137,9 @@ func (s *Service) checkStatus() bool {
 		return true
 	}
 	return false
+}
+
+// Debug sets whether we output debugging into when starting Driver
+func (s *Service) Debug(setting bool) {
+	s.debug = setting
 }

--- a/api/webdriver.go
+++ b/api/webdriver.go
@@ -19,6 +19,7 @@ type driverService interface {
 	Start() error
 	Stop() error
 	WaitForBoot(timeout time.Duration) error
+	Debug(bool)
 }
 
 func NewWebDriver(url string, command []string) *WebDriver {
@@ -31,6 +32,10 @@ func NewWebDriver(url string, command []string) *WebDriver {
 		Timeout: 5 * time.Second,
 		service: driverService,
 	}
+}
+
+func (w *WebDriver) Debug(setting bool) {
+	w.service.Debug(setting)
 }
 
 func (w *WebDriver) Open(desiredCapabilites map[string]interface{}) (*Session, error) {


### PR DESCRIPTION
It occured twice this week that we discovered the problem when reading
the output of the driver being run.
