### PR TITLE
Firefox driver support

### DIFF
--- a/agouti.go
+++ b/agouti.go
@@ -5,6 +5,7 @@ package agouti
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 )
@@ -103,4 +104,26 @@ func SauceLabs(name, platform, browser, version, username, accessKey string, opt
 	capabilities := NewCapabilities().Browser(name).Platform(platform).Version(version)
 	capabilities["name"] = name
 	return NewPage(url, append([]Option{Desired(capabilities)}, options...)...)
+}
+
+func getFirefoxDriverBinaryArgument() string {
+	list := []string{"C:\\Program Files\\Firefox Developer Edition\\firefox.exe", "C:\\Program Files (x86)\\Firefox Developer Edition\\firefox.exe", "C:\\Program Files\\Mozilla Firefox\\firefox.exe", "C:\\Program Files (x86)\\Mozilla Firefox\\firefox.exe"}
+	for _, binaryPath := range list {
+		if _, err := os.Stat(binaryPath); os.IsNotExist(err) {
+			continue
+		}
+		return "--binary=" + binaryPath
+	}
+	return "--connect-existing"
+}
+
+func FirefoxDriver(options ...Option) *WebDriver {
+	var binaryName string
+	if runtime.GOOS == "windows" {
+		binaryName = "wires.exe"
+	} else {
+		binaryName = "wires"
+	}
+	command := []string{binaryName, getFirefoxDriverBinaryArgument(), "--webdriver-port={{.Port}}"}
+	return NewWebDriver("http://{{.Address}}", command, options...)
 }

--- a/agouti.go
+++ b/agouti.go
@@ -107,23 +107,39 @@ func SauceLabs(name, platform, browser, version, username, accessKey string, opt
 
 // Example:
 //
-// capabilities := agouti.NewCapabilities()
-// capabilities["binary"] = "C:\\Program Files (x86)\\Firefox Developer Edition\\firefox.exe"
-// driver, err := agouti.FirefoxDriver(agouti.Desired(capabilities))
-func FirefoxDriver(options ...Option) (*WebDriver, error) {
-	var binaryFirefox string
-	defaultOptions := config{}.Merge(options)
-	binaryFirefox, ok := defaultOptions.DesiredCapabilities["binary"].(string)
-	if !ok {
-		return nil, fmt.Errorf("\"binary\" capability is not specified")
-	}
-
-	var binaryName string
+// 	capabilities := agouti.NewCapabilities()
+//	capabilities[""] = ""
+//  driver := agouti.FirefoxDriver()
+//	err := driver.Start()
+//	if err != nil {
+//		fmt.Printf("Start: %s\n", err)
+//	}
+//
+//	page, err := driver.NewPage()
+//	if err != nil {
+//		fmt.Printf("NewPage: %s\n", err)
+//		return
+//	}
+//
+//	err = page.Navigate("http://ya.ru")
+//	if err != nil {
+//		fmt.Printf("Navigate: %s", err)
+//		return
+//	}
+//
+//  err = driver.Stop()
+//	if err != nil {
+//		fmt.Printf("Stop: %s\n", err)
+//	}
+func FirefoxDriver(options ...Option) (*WebDriver) {
+	var binaryDriver string
 	if runtime.GOOS == "windows" {
-		binaryName = "wires.exe"
+		binaryDriver = "geckodriver.exe"
 	} else {
-		binaryName = "wires"
+		binaryDriver = "geckodriver"
 	}
-	command := []string{binaryName, "--binary=" + binaryFirefox, "--webdriver-port={{.Port}}"}
-	return NewWebDriver("http://{{.Address}}", command, options...), nil
+	command := []string{binaryDriver, "--port={{.Port}}"}
+	options = append(options, Debug)
+	return NewWebDriver("http://{{.Address}}", command, options...)
 }
+

--- a/agouti.go
+++ b/agouti.go
@@ -106,24 +106,25 @@ func SauceLabs(name, platform, browser, version, username, accessKey string, opt
 	return NewPage(url, append([]Option{Desired(capabilities)}, options...)...)
 }
 
-func getFirefoxDriverBinaryArgument() string {
-	list := []string{"C:\\Program Files\\Firefox Developer Edition\\firefox.exe", "C:\\Program Files (x86)\\Firefox Developer Edition\\firefox.exe", "C:\\Program Files\\Mozilla Firefox\\firefox.exe", "C:\\Program Files (x86)\\Mozilla Firefox\\firefox.exe"}
-	for _, binaryPath := range list {
-		if _, err := os.Stat(binaryPath); os.IsNotExist(err) {
-			continue
-		}
-		return "--binary=" + binaryPath
+// Example:
+//
+// capabilities := agouti.NewCapabilities()
+// capabilities["binary"] = "C:\\Program Files (x86)\\Firefox Developer Edition\\firefox.exe"
+// driver, err := agouti.FirefoxDriver(agouti.Desired(capabilities))
+func FirefoxDriver(options ...Option) (*WebDriver, error) {
+	var binaryFirefox string
+	defaultOptions := config{}.Merge(options)
+	binaryFirefox, ok := defaultOptions.DesiredCapabilities["binary"].(string)
+	if !ok {
+		return nil, fmt.Errorf("\"binary\" capability is not specified")
 	}
-	return "--connect-existing"
-}
 
-func FirefoxDriver(options ...Option) *WebDriver {
 	var binaryName string
 	if runtime.GOOS == "windows" {
 		binaryName = "wires.exe"
 	} else {
 		binaryName = "wires"
 	}
-	command := []string{binaryName, getFirefoxDriverBinaryArgument(), "--webdriver-port={{.Port}}"}
-	return NewWebDriver("http://{{.Address}}", command, options...)
+	command := []string{binaryName, "--binary=" + binaryFirefox, "--webdriver-port={{.Port}}"}
+	return NewWebDriver("http://{{.Address}}", command, options...), nil
 }

--- a/agouti.go
+++ b/agouti.go
@@ -5,7 +5,6 @@ package agouti
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"runtime"
 )


### PR DESCRIPTION
1. FireFox driver doesn't search for firefox binary so user have to specify "binary" capability.
2. Unfortunately driver doesn't support "/status" command, I've tried to do something smart with using bus.Connect to check status but it starts crashing, so I've stopped on "response.StatusCode == 404".
