### PR TITLE
Add support for nanoseconds in cookie expiry date

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -27,7 +27,7 @@ type Cookie struct {
 	HTTPOnly bool `json:"httpOnly,omitempty"`
 
 	// Expiry is the time when the cookie expires
-	Expiry int64 `json:"expiry,omitempty"`
+	Expiry float64 `json:"expiry,omitempty"`
 }
 
 type Selector struct {

--- a/page.go
+++ b/page.go
@@ -120,7 +120,7 @@ func (p *Page) GetCookies() ([]*http.Cookie, error) {
 		return nil, fmt.Errorf("failed to get cookies: %s", err)
 	}
 	expSeconds := int64(apiCookie.Expiry)
-	expNano := int64(apiCookie.Expiry - float64(unixSeconds))
+	expNano := int64(apiCookie.Expiry - float64(expSeconds))
 	cookies := []*http.Cookie{}
 	for _, apiCookie := range apiCookies {
 		cookie := &http.Cookie{

--- a/page.go
+++ b/page.go
@@ -119,10 +119,10 @@ func (p *Page) GetCookies() ([]*http.Cookie, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cookies: %s", err)
 	}
-	expSeconds := int64(apiCookie.Expiry)
-	expNano := int64(apiCookie.Expiry-float64(expSeconds)) * 1000000000
 	cookies := []*http.Cookie{}
 	for _, apiCookie := range apiCookies {
+		expSeconds := int64(apiCookie.Expiry)
+		expNano := int64(apiCookie.Expiry-float64(expSeconds)) * 1000000000
 		cookie := &http.Cookie{
 			Name:     apiCookie.Name,
 			Value:    apiCookie.Value,

--- a/page.go
+++ b/page.go
@@ -119,6 +119,8 @@ func (p *Page) GetCookies() ([]*http.Cookie, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cookies: %s", err)
 	}
+	expSeconds := int64(apiCookie.Expiry)
+	expNano := int64(apiCookie.Expiry - float64(unixSeconds))
 	cookies := []*http.Cookie{}
 	for _, apiCookie := range apiCookies {
 		cookie := &http.Cookie{
@@ -128,7 +130,7 @@ func (p *Page) GetCookies() ([]*http.Cookie, error) {
 			Domain:   apiCookie.Domain,
 			Secure:   apiCookie.Secure,
 			HttpOnly: apiCookie.HTTPOnly,
-			Expires:  time.Unix(apiCookie.Expiry, 0),
+			Expires:  time.Unix(expSeconds, expNano),
 		}
 		cookies = append(cookies, cookie)
 	}
@@ -153,7 +155,7 @@ func (p *Page) SetCookie(cookie *http.Cookie) error {
 		Domain:   cookie.Domain,
 		Secure:   cookie.Secure,
 		HTTPOnly: cookie.HttpOnly,
-		Expiry:   expiry,
+		Expiry:   float64(expiry),
 	}
 
 	if err := p.session.SetCookie(apiCookie); err != nil {

--- a/page.go
+++ b/page.go
@@ -120,7 +120,7 @@ func (p *Page) GetCookies() ([]*http.Cookie, error) {
 		return nil, fmt.Errorf("failed to get cookies: %s", err)
 	}
 	expSeconds := int64(apiCookie.Expiry)
-	expNano := int64(apiCookie.Expiry - float64(expSeconds))
+	expNano := int64(apiCookie.Expiry-float64(expSeconds)) * 1000000000
 	cookies := []*http.Cookie{}
 	for _, apiCookie := range apiCookies {
 		cookie := &http.Cookie{


### PR DESCRIPTION
`agouti` currently assumes that the `expiry` field received in the JSON response for the `cookies` endpoint will be an integer, not a float. But some cookies have expiration dates that include nanoseconds, and the JSON response from the `cookies` endpoint will use a float in this case. This causes the JSON unmarshaling to fail.

To reproduce: use any webdriver to log in to facebook.com. After the news feed loads, call `page.GetCookies()`. `agouti` will error out because of the unexpected JSON response.