### PR TITLE
Add a Clear method for Selection

### DIFF
--- a/selection_actions.go
+++ b/selection_actions.go
@@ -48,6 +48,16 @@ func (s *Selection) DoubleClick() error {
 	})
 }
 
+// Clear clears all fields the selection refers to.
+func (s *Selection) Clear() error {
+        return s.forEachElement(func(selectedElement element.Element) error {
+                if err := selectedElement.Clear(); err != nil {
+                        return fmt.Errorf("failed to clear %s: %s", s, err)
+                }
+                return nil
+        })
+}
+
 // Fill fills all of the fields the selection refers to with the provided text.
 func (s *Selection) Fill(text string) error {
 	return s.forEachElement(func(selectedElement element.Element) error {

--- a/selection_actions_test.go
+++ b/selection_actions_test.go
@@ -130,6 +130,28 @@ var _ = Describe("Selection Actions", func() {
 		})
 	})
 
+	Describe("#Clear", func() {
+		It("should successfully clear each element", func() {
+			Expect(selection.Clear()).To(Succeed())
+			Expect(firstElement.ClearCall.Called).To(BeTrue())
+			Expect(secondElement.ClearCall.Called).To(BeTrue())
+		})
+
+		Context("when zero elements are returned", func() {
+			It("should return an error", func() {
+				elementRepository.GetAtLeastOneCall.Err = errors.New("some error")
+				Expect(selection.Clear()).To(MatchError("failed to select elements from selection 'CSS: #selector': some error"))
+			})
+		})
+
+		Context("when clearing any element fails", func() {
+			It("should return an error", func() {
+				secondElement.ClearCall.Err = errors.New("some error")
+				Expect(selection.Clear()).To(MatchError("failed to clear selection 'CSS: #selector': some error"))
+			})
+		})
+	})
+
 	Describe("#UploadFile", func() {
 		BeforeEach(func() {
 			firstElement.GetAttributeCall.ReturnValue = "file"


### PR DESCRIPTION
This change adds a simple method for clearing text boxes, essentially equivalent to `selection.Fill("")`. Tests have been added that correspond to those for `Fill`.

Please rebase the PR if needed, or ask me to do so. Tests pass when run locally (via `GOPATH=~/projects/agouti/ go test -v`):

```
=== RUN   TestAgouti
Running Suite: Agouti Suite
===========================
Random Seed: 1471912577
Will run 225 of 225 specs

•••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
Ran 225 of 225 Specs in 0.002 seconds
SUCCESS! -- 225 Passed | 0 Failed | 0 Pending | 0 Skipped --- PASS: TestAgouti (0.00s)
PASS
ok  	github.com/sclevine/agouti	0.039s
```

Signed-off-by: Jonathan Yu <jawnsy@cpan.org>