### PR TITLE
Close HTTP response body and empty it to avoid resource leaks and make use of keep-alive

### DIFF
--- a/api/internal/bus/client.go
+++ b/api/internal/bus/client.go
@@ -61,6 +61,7 @@ func (c *Client) makeRequest(url, method string, body []byte) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %s", err)
 	}
+	defer response.Body.Close()
 
 	responseBody, err := ioutil.ReadAll(response.Body)
 	if err != nil {

--- a/api/internal/bus/connect.go
+++ b/api/internal/bus/connect.go
@@ -56,6 +56,7 @@ func openSession(url string, body io.Reader, httpClient *http.Client) (sessionID
 	if err != nil {
 		return "", err
 	}
+	defer response.Body.Close()
 
 	var sessionResponse struct{ SessionID string }
 	responseBody, err := ioutil.ReadAll(response.Body)

--- a/api/internal/service/service.go
+++ b/api/internal/service/service.go
@@ -3,8 +3,6 @@ package service
 import (
 	"errors"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -141,7 +139,6 @@ func (s *Service) checkStatus() bool {
 		return false
 	}
 	defer response.Body.Close()
-	io.Copy(ioutil.Discard, response.Body)
 	if response.StatusCode == 200 {
 		return true
 	}

--- a/api/internal/service/service.go
+++ b/api/internal/service/service.go
@@ -3,6 +3,8 @@ package service
 import (
 	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -135,7 +137,12 @@ func (s *Service) checkStatus() bool {
 	client := &http.Client{}
 	request, _ := http.NewRequest("GET", fmt.Sprintf("%s/status", s.url), nil)
 	response, err := client.Do(request)
-	if err == nil && response.StatusCode == 200 {
+	if err != nil {
+		return false
+	}
+	defer response.Body.Close()
+	io.Copy(ioutil.Discard, response.Body)
+	if response.StatusCode == 200 {
 		return true
 	}
 	return false


### PR DESCRIPTION
As per documentation:
```
When err is nil, resp always contains a non-nil resp.Body. Caller should close resp.Body when done reading from it.
```