### PR TITLE
Add ChromeOptions

### DIFF
--- a/options.go
+++ b/options.go
@@ -12,6 +12,7 @@ type config struct {
 	RejectInvalidSSL    bool
 	Debug               bool
 	HTTPClient          *http.Client
+	ChromeOptions       map[string]interface{}
 }
 
 // An Option specifies configuration for a new WebDriver or Page.
@@ -28,6 +29,16 @@ func Browser(name string) Option {
 func Timeout(seconds int) Option {
 	return func(c *config) {
 		c.Timeout = time.Duration(seconds) * time.Second
+	}
+}
+
+// ChromeOptions is used to pass additional options to Chrome via ChromeDriver.
+func ChromeOptions(opt string, value interface{}) Option {
+	return func(c *config) {
+		if c.ChromeOptions == nil {
+			c.ChromeOptions = make(map[string]interface{})
+		}
+		c.ChromeOptions[opt] = value
 	}
 }
 
@@ -71,6 +82,9 @@ func (c *config) Capabilities() Capabilities {
 	}
 	if c.BrowserName != "" {
 		merged.Browser(c.BrowserName)
+	}
+	if c.ChromeOptions != nil {
+		merged["chromeOptions"] = c.ChromeOptions
 	}
 	if c.RejectInvalidSSL {
 		merged.Without("acceptSslCerts")

--- a/options_test.go
+++ b/options_test.go
@@ -63,14 +63,23 @@ var _ = Describe("Options", func() {
 		})
 	})
 
+	Describe("#ChromeOptions", func() {
+		It("should return an Option with ChromeOptions set", func() {
+			config := NewTestConfig()
+			ChromeOptions("args", []string{"v1", "v2"})(config)
+			Expect(config.ChromeOptions["args"]).To(Equal([]string{"v1", "v2"}))
+		})
+	})
+
 	Describe("#Merge", func() {
 		It("should apply any provided options to an existing config", func() {
 			config := NewTestConfig()
 			Browser("some browser")(config)
-			newConfig := config.Merge([]Option{Timeout(5), Debug})
+			newConfig := config.Merge([]Option{Timeout(5), Debug, ChromeOptions("args", "value")})
 			Expect(newConfig.BrowserName).To(Equal("some browser"))
 			Expect(newConfig.Timeout).To(Equal(5 * time.Second))
 			Expect(newConfig.Debug).To(BeTrue())
+			Expect(newConfig.ChromeOptions).To(Equal(map[string]interface{}{"args": "value"}))
 		})
 	})
 
@@ -85,6 +94,10 @@ var _ = Describe("Options", func() {
 			RejectInvalidSSL(config)
 			Expect(config.Capabilities()["browserName"]).To(Equal("some other browser"))
 			Expect(config.Capabilities()["acceptSslCerts"]).To(BeFalse())
+			ChromeOptions("args", "someArg")(config)
+			Expect(config.Capabilities()["chromeOptions"]).To(
+				Equal(map[string]interface{}{"args": "someArg"}),
+			)
 		})
 	})
 })

--- a/options_test.go
+++ b/options_test.go
@@ -68,6 +68,9 @@ var _ = Describe("Options", func() {
 			config := NewTestConfig()
 			ChromeOptions("args", []string{"v1", "v2"})(config)
 			Expect(config.ChromeOptions["args"]).To(Equal([]string{"v1", "v2"}))
+			ChromeOptions("other", "value")(config)
+			Expect(config.ChromeOptions["args"]).To(Equal([]string{"v1", "v2"}))
+			Expect(config.ChromeOptions["other"]).To(Equal("value"))
 		})
 	})
 
@@ -75,11 +78,10 @@ var _ = Describe("Options", func() {
 		It("should apply any provided options to an existing config", func() {
 			config := NewTestConfig()
 			Browser("some browser")(config)
-			newConfig := config.Merge([]Option{Timeout(5), Debug, ChromeOptions("args", "value")})
+			newConfig := config.Merge([]Option{Timeout(5), Debug})
 			Expect(newConfig.BrowserName).To(Equal("some browser"))
 			Expect(newConfig.Timeout).To(Equal(5 * time.Second))
 			Expect(newConfig.Debug).To(BeTrue())
-			Expect(newConfig.ChromeOptions).To(Equal(map[string]interface{}{"args": "value"}))
 		})
 	})
 


### PR DESCRIPTION
This allows passing additional options to chrome. For example to pass `--headless` and use a different binary, it'd look like this:
```go
	wd := agouti.ChromeDriver(
		agouti.Browser("chrome"),
		agouti.ChromeOptions("binary", "/path/to/chrome"),
		agouti.ChromeOptions("args", []string{"--headless"}),
	)
	if err := wd.Start(); err != nil {
		panic(err)
	}
	defer wd.Stop()
	p, err := wd.NewPage()
	if err != nil {
		panic(err)
	}
	if err = p.Navigate("https://www.google.com"); err != nil {
		panic(err)
	}
```

While it's possible to pass those values via Capabilities, the Option make it more convenient and clear.