### PR TITLE
support geckodriver (Firefox)

### DIFF
--- a/agouti.go
+++ b/agouti.go
@@ -104,3 +104,20 @@ func SauceLabs(name, platform, browser, version, username, accessKey string, opt
 	capabilities["name"] = name
 	return NewPage(url, append([]Option{Desired(capabilities)}, options...)...)
 }
+
+// GeckoDriver returns an instance of a geckodriver WebDriver which supports
+// gecko based brwoser like Firefox.
+//
+// Provided Options will apply as default arguments for new pages.
+//
+// See https://github.com/mozilla/geckodriver for geckodriver details.
+func GeckoDriver(options ...Option) *WebDriver {
+	var binaryName string
+	if runtime.GOOS == "windows" {
+		binaryName = "geckodriver.exe"
+	} else {
+		binaryName = "geckodriver"
+	}
+	command := []string{binaryName, "--port={{.Port}}"}
+	return NewWebDriver("http://{{.Address}}", command, options...)
+}

--- a/api/internal/bus/connect.go
+++ b/api/internal/bus/connect.go
@@ -58,7 +58,13 @@ func openSession(url string, body io.Reader, httpClient *http.Client) (sessionID
 	}
 	defer response.Body.Close()
 
-	var sessionResponse struct{ SessionID string }
+	var sessionResponse struct {
+		SessionID string
+		// fallback for GeckoDriver
+		Value struct {
+			SessionID string
+		}
+	}
 	responseBody, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return "", err
@@ -69,6 +75,10 @@ func openSession(url string, body io.Reader, httpClient *http.Client) (sessionID
 	}
 
 	if sessionResponse.SessionID == "" {
+		// fallback for GeckoDriver
+		if sessionResponse.Value.SessionID != "" {
+			return sessionResponse.Value.SessionID, nil
+		}
 		return "", errors.New("failed to retrieve a session ID")
 	}
 


### PR DESCRIPTION
This PR adding support for [geckodriver](https://github.com/mozilla/geckodriver) which works with Firefox or gecko based browsers.

I know other PR https://github.com/sclevine/agouti/pull/66 exists.
But it seems be stagnant, so I create a revised one.