### PR TITLE
to run tests for forked repos on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ go:
  - 1.7
  - 1.8
  - 1.9
+go_import_path: github.com/sclevine/agouti
 
 script:
  - go test -v ./...


### PR DESCRIPTION
`go_import_path` is necessary to run tests on travis-ci for forked repositories.

See https://docs.travis-ci.com/user/languages/go/#Go-Import-Path