### PR TITLE
Allow to join page with custom HTTP client

### DIFF
--- a/api/session.go
+++ b/api/session.go
@@ -18,7 +18,11 @@ type Bus interface {
 }
 
 func New(sessionURL string) *Session {
-	busClient := &bus.Client{sessionURL, http.DefaultClient}
+	return NewWithClient(sessionURL, http.DefaultClient)
+}
+
+func NewWithClient(sessionURL string, client *http.Client) *Session {
+	busClient := &bus.Client{sessionURL, client}
 	return &Session{busClient}
 }
 

--- a/api/session.go
+++ b/api/session.go
@@ -18,10 +18,13 @@ type Bus interface {
 }
 
 func New(sessionURL string) *Session {
-	return NewWithClient(sessionURL, http.DefaultClient)
+	return NewWithClient(sessionURL, nil)
 }
 
 func NewWithClient(sessionURL string, client *http.Client) *Session {
+	if client == nil {
+		client = http.DefaultClient
+	}
 	busClient := &bus.Client{sessionURL, client}
 	return &Session{busClient}
 }

--- a/page.go
+++ b/page.go
@@ -54,6 +54,12 @@ func JoinPage(url string) *Page {
 	return newPage(session)
 }
 
+// JoinPageWithClient creates a Page using existing session URL and provided HTTP Client
+func JoinPageWithClient(url string, client *http.Client) *Page {
+	session := api.NewWithClient(url, client)
+	return newPage(session)
+}
+
 func newPage(session *api.Session) *Page {
 	return &Page{selectable{session, nil}, nil}
 }

--- a/page.go
+++ b/page.go
@@ -48,15 +48,11 @@ func NewPage(url string, options ...Option) (*Page, error) {
 	return newPage(session), nil
 }
 
-// JoinPage creates a Page using existing session URL.
-func JoinPage(url string) *Page {
-	session := api.New(url)
-	return newPage(session)
-}
-
-// JoinPageWithClient creates a Page using existing session URL and provided HTTP Client
-func JoinPageWithClient(url string, client *http.Client) *Page {
-	session := api.NewWithClient(url, client)
+// JoinPage creates a Page using existing session URL. This method takes Options
+// but respects only the HTTPClient Option if provided.
+func JoinPage(url string, options ...Option) *Page {
+	pageOptions := config{}.Merge(options)
+	session := api.NewWithClient(url, pageOptions.HTTPClient)
 	return newPage(session)
 }
 


### PR DESCRIPTION
It was possible to create a new page with custom HTTP client using `agouti.NewPage`, but was unable to join a running webdriver session with custom HTTP client: `agouti.JoinPage` did not offer a way to do that.

In order not to break an existing API, this PR introduces a new method to join the running session using custom HTTP client.