### PR TITLE
Expose session URL

### DIFF
--- a/api/internal/bus/client.go
+++ b/api/internal/bus/client.go
@@ -14,6 +14,10 @@ type Client struct {
 	HTTPClient *http.Client
 }
 
+func (c *Client) GetSessionURL() string {
+	return c.SessionURL
+}
+
 func (c *Client) Send(method, endpoint string, body interface{}, result interface{}) error {
 	requestBody, err := bodyToJSON(body)
 	if err != nil {

--- a/api/internal/mocks/bus.go
+++ b/api/internal/mocks/bus.go
@@ -21,3 +21,7 @@ func (b *Bus) Send(method, endpoint string, body, result interface{}) error {
 	}
 	return b.SendCall.Err
 }
+
+func (b *Bus) GetSessionURL() string {
+	return "mock"
+}

--- a/api/session.go
+++ b/api/session.go
@@ -15,6 +15,7 @@ type Session struct {
 
 type Bus interface {
 	Send(method, endpoint string, body, result interface{}) error
+	GetSessionURL() string
 }
 
 func New(sessionURL string) *Session {
@@ -39,6 +40,10 @@ func OpenWithClient(url string, capabilities map[string]interface{}, client *htt
 		return nil, err
 	}
 	return &Session{busClient}, nil
+}
+
+func (s *Session) URL() string {
+	return s.Bus.GetSessionURL()
 }
 
 func (s *Session) Delete() error {

--- a/internal/mocks/bus.go
+++ b/internal/mocks/bus.go
@@ -21,3 +21,7 @@ func (b *Bus) Send(method, endpoint string, body, result interface{}) error {
 	}
 	return b.SendCall.Err
 }
+
+func (b *Bus) GetSessionURL() string {
+	return "mock"
+}


### PR DESCRIPTION
Session URL is useful for:
Better monitoring the session lifetime and link to errors.
Using JoinPage for reusing a single chromedriver process for multiple sessions.

As a result, exposing the SessionURL should be part of the public API instead of using reflection.

