### PR TITLE
Support w3c elements

### DIFF
--- a/api/element.go
+++ b/api/element.go
@@ -6,6 +6,18 @@ import (
 	"strings"
 )
 
+type elementResult struct {
+	Element    string `json:"ELEMENT"`
+	W3CElement string `json:"element-6066-11e4-a52e-4f735466cecf"`
+}
+
+func (er elementResult) ID() string {
+	if er.Element != "" {
+		return er.Element
+	}
+	return er.W3CElement
+}
+
 type Element struct {
 	ID      string
 	Session *Session
@@ -20,7 +32,7 @@ func (e *Element) GetID() string {
 }
 
 func (e *Element) GetElement(selector Selector) (*Element, error) {
-	var result struct{ Element string }
+	var result elementResult
 
 	if err := e.Send("POST", "element", selector, &result); err != nil {
 		return nil, err
@@ -30,7 +42,7 @@ func (e *Element) GetElement(selector Selector) (*Element, error) {
 }
 
 func (e *Element) GetElements(selector Selector) ([]*Element, error) {
-	var results []struct{ Element string }
+	var results []elementResult
 
 	if err := e.Send("POST", "elements", selector, &results); err != nil {
 		return nil, err
@@ -144,7 +156,7 @@ func (e *Element) GetLocation() (x, y int, err error) {
 
 func (e *Element) GetSize() (width, height int, err error) {
 	var size struct {
-		Width float64 `json:"width"`
+		Width  float64 `json:"width"`
 		Height float64 `json:"height"`
 	}
 	if err := e.Send("GET", "size", nil, &size); err != nil {

--- a/api/element.go
+++ b/api/element.go
@@ -38,7 +38,7 @@ func (e *Element) GetElement(selector Selector) (*Element, error) {
 		return nil, err
 	}
 
-	return &Element{result.Element, e.Session}, nil
+	return &Element{result.ID(), e.Session}, nil
 }
 
 func (e *Element) GetElements(selector Selector) ([]*Element, error) {
@@ -50,7 +50,7 @@ func (e *Element) GetElements(selector Selector) ([]*Element, error) {
 
 	elements := []*Element{}
 	for _, result := range results {
-		elements = append(elements, &Element{result.Element, e.Session})
+		elements = append(elements, &Element{result.ID(), e.Session})
 	}
 
 	return elements, nil

--- a/api/session.go
+++ b/api/session.go
@@ -46,17 +46,17 @@ func (s *Session) Delete() error {
 }
 
 func (s *Session) GetElement(selector Selector) (*Element, error) {
-	var result struct{ Element string }
+	var result elementResult
 
 	if err := s.Send("POST", "element", selector, &result); err != nil {
 		return nil, err
 	}
 
-	return &Element{result.Element, s}, nil
+	return &Element{result.ID(), s}, nil
 }
 
 func (s *Session) GetElements(selector Selector) ([]*Element, error) {
-	var results []struct{ Element string }
+	var results []elementResult
 
 	if err := s.Send("POST", "elements", selector, &results); err != nil {
 		return nil, err
@@ -64,20 +64,20 @@ func (s *Session) GetElements(selector Selector) ([]*Element, error) {
 
 	elements := []*Element{}
 	for _, result := range results {
-		elements = append(elements, &Element{result.Element, s})
+		elements = append(elements, &Element{result.ID(), s})
 	}
 
 	return elements, nil
 }
 
 func (s *Session) GetActiveElement() (*Element, error) {
-	var result struct{ Element string }
+	var result elementResult
 
 	if err := s.Send("POST", "element/active", nil, &result); err != nil {
 		return nil, err
 	}
 
-	return &Element{result.Element, s}, nil
+	return &Element{result.ID(), s}, nil
 }
 
 func (s *Session) GetWindow() (*Window, error) {


### PR DESCRIPTION
Elements can be returned via `ELEMENT` or `element-6066-11e4-a52e-4f735466cecf`. This updates the code to support either.

You can see an example in the python driver here: https://github.com/SeleniumHQ/selenium/blob/eb4a3c475c10ef0c7d65dce45fa179ce2c109e5d/py/selenium/webdriver/remote/webdriver.py#L282

I noticed this issue attempting to run tests against macos/safari on sauce labs.