### PR TITLE
Add support for arbitrary string key-value pairs for capabilities

### DIFF
--- a/capabilities.go
+++ b/capabilities.go
@@ -82,6 +82,12 @@ func (c Capabilities) Without(feature string) Capabilities {
 	return c
 }
 
+// Sets an arbitrary key-value pair (ex. "udid")
+func (c Capabilities) Set(key string, value string) Capabilities {
+	c[key] = value
+	return c
+}
+
 // JSON returns a JSON string representing the desired capabilities.
 func (c Capabilities) JSON() (string, error) {
 	capabilitiesJSON, err := json.Marshal(c)

--- a/capabilities_test.go
+++ b/capabilities_test.go
@@ -16,6 +16,7 @@ var _ = Describe("Capabilities", func() {
 	It("should successfully encode all provided options into JSON", func() {
 		capabilities.Browser("some-browser").Version("v100").Platform("some-os")
 		capabilities.With("withEnabled").Without("withoutDisabled")
+		capabilities.Set("deviceName", "some-device-name").Set("udid", "some-udid")
 		capabilities.Proxy(ProxyConfig{
 			ProxyType: "manual",
 			HTTPProxy: "some-http-proxy",
@@ -27,6 +28,8 @@ var _ = Describe("Capabilities", func() {
 			"platform": "some-os",
 			"withEnabled": true,
 			"withoutDisabled": false,
+			"deviceName": "some-device-name",
+			"udid": "some-udid",
 			"firstEnabled": true,
 			"secondEnabled": true,
 			"proxy": {


### PR DESCRIPTION
For Appium, there are required capabilities that are key-value pairs with strings being the values. This PR adds support to the Capabilities struct to chain key-value pairs for supporting such capabilities.