### PR TITLE
Allow connecting to already running appium service

### DIFF
--- a/api/internal/service/running_service.go
+++ b/api/internal/service/running_service.go
@@ -1,0 +1,79 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+/** A running service is a service that is already running
+  * and does not need to be started.
+  * It has a fixed Url and port.
+ */
+type RunningService struct {
+	sync.RWMutex
+	Url         string
+}
+
+func (s *RunningService) URL() string {
+	return s.Url
+}
+
+func (s *RunningService) Start(debug bool) error {
+	// Nothing to do, it is already started
+	return nil
+}
+
+func (s *RunningService) Stop() error {
+	s.Lock()
+	s.Url = ""
+	s.Unlock()
+
+	return nil
+}
+
+func (s *RunningService) WaitForBoot(timeout time.Duration) error {
+	timeoutChan := time.After(timeout)
+	failedChan := make(chan struct{}, 1)
+	startedChan := make(chan struct{})
+
+	go func() {
+		up := s.checkStatus()
+		for !up {
+			select {
+			case <-failedChan:
+				return
+			default:
+				time.Sleep(500 * time.Millisecond)
+				up = s.checkStatus()
+			}
+		}
+		startedChan <- struct{}{}
+	}()
+
+	select {
+	case <-timeoutChan:
+		failedChan <- struct{}{}
+		return errors.New("failed to start before timeout")
+	case <-startedChan:
+		return nil
+	}
+}
+
+func (s *RunningService) checkStatus() bool {
+	client := &http.Client{}
+	s.Lock()
+	request, _ := http.NewRequest("GET", fmt.Sprintf("%s/status", s.Url), nil)
+	s.Unlock()
+	response, err := client.Do(request)
+	if err != nil {
+		return false
+	}
+	defer response.Body.Close()
+	if response.StatusCode == 200 {
+		return true
+	}
+	return false
+}

--- a/api/webdriver.go
+++ b/api/webdriver.go
@@ -35,6 +35,17 @@ func NewWebDriver(url string, command []string) *WebDriver {
 	}
 }
 
+func NewWebDriverWithRunningService(url string) *WebDriver {
+	driverService := &service.RunningService{
+		Url: url,
+	}
+
+	return &WebDriver{
+		Timeout: 10 * time.Second,
+		service: driverService,
+	}
+}
+
 func (w *WebDriver) URL() string {
 	return w.service.URL()
 }

--- a/appium/webdriver.go
+++ b/appium/webdriver.go
@@ -19,6 +19,12 @@ func New(options ...Option) *WebDriver {
 	return &WebDriver{agoutiWebDriver}
 }
 
+func NewWithRunningAppiumService(host string, port int, options ...Option) *WebDriver {
+	newOptions := config{}.merge(options)
+	agoutiWebDriver := agouti.NewWebDriverWithRunningService(fmt.Sprintf("http://%s:%d/wd/hub", host, port), newOptions.agoutiOptions...)
+	return &WebDriver{agoutiWebDriver}
+}
+
 func (w *WebDriver) NewDevice(options ...Option) (*Device, error) {
 	newOptions := config{}.merge(options)
 	page, err := w.driver.NewPage(newOptions.agoutiOptions...)

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/sclevine/agouti
+
+go 1.13

--- a/selectable.go
+++ b/selectable.go
@@ -106,6 +106,16 @@ func (s *selectable) FindByID(id string) *Selection {
 	return newSelection(s.session, s.selectors.Append(target.ID, id).Single())
 }
 
+//Find by android ui automator
+func (s *selectable) FindByAndroidUIAutomator(selector string) * Selection {
+	return newSelection(s.session, s.selectors.Append(target.AndroidAut, selector).Single())
+}
+
+//Find by iOS ui automator
+func (s *selectable) FindByIOSUIAutomator(selector string) * Selection {
+	return newSelection(s.session, s.selectors.Append(target.IOSAut, selector).Single())
+}
+
 // First finds the first element by CSS selector.
 func (s *selectable) First(selector string) *Selection {
 	return newSelection(s.session, s.selectors.Append(target.CSS, selector).At(0))
@@ -140,6 +150,16 @@ func (s *selectable) FirstByName(name string) *Selection {
 // FirstByClass finds the first element with a given CSS class.
 func (s *selectable) FirstByClass(text string) *Selection {
 	return newSelection(s.session, s.selectors.Append(target.Class, text).At(0))
+}
+
+//FirstByAndroidUIAutomator finds the first element given by the ui automation expression.
+func (s *selectable) FirstByAndroidUIAutomator(selector string) * Selection {
+	return newSelection(s.session, s.selectors.Append(target.AndroidAut, selector).At(0))
+}
+
+//FirstByIOSUIAutomator finds the first element given by the ui automation expression.
+func (s *selectable) FirstByIOSUIAutomator(selector string) * Selection {
+	return newSelection(s.session, s.selectors.Append(target.IOSAut, selector).At(0))
 }
 
 // All finds zero or more elements by CSS selector.
@@ -181,6 +201,16 @@ func (s *selectable) AllByClass(text string) *MultiSelection {
 // AllByID finds zero or more elements with a given ID.
 func (s *selectable) AllByID(text string) *MultiSelection {
 	return newMultiSelection(s.session, s.selectors.Append(target.ID, text))
+}
+
+//Find by android ui automator
+func (s *selectable) AllByAndroidUIAutomator(text string) * Selection {
+	return newSelection(s.session, s.selectors.Append(target.AndroidAut, text).Single())
+}
+
+//Find by ios ui automator
+func (s *selectable) AllByIOSUIAutomator(text string) * Selection {
+	return newSelection(s.session, s.selectors.Append(target.IOSAut, text).Single())
 }
 
 // FirstByClass finds the first element with a given CSS class.

--- a/webdriver.go
+++ b/webdriver.go
@@ -13,6 +13,31 @@ type WebDriver struct {
 	defaultOptions *config
 }
 
+// NewWebDriverWithRunningService returns an instance of a WebDriver specified by
+// a URL. The service is expected to be already running and reachable by the url.
+// The URL should be the location of the WebDriver Wire Protocol web service.
+//
+// The Timeout Option specifies how many seconds to wait for the web service
+// to become available. The default timeout is 5 seconds.
+//
+// The HTTPClient Option specifies a *http.Client to use for all WebDriver
+// communications. The default client is http.DefaultClient.
+//
+// Any other provided Options are treated as default Options for new pages.
+//
+// In difference to NewWebDriver, url is not a template but the finished url.
+//
+// Example:
+//   agouti.NewWebDriverWithRunningService("http://localhost:1234/wd/hub")
+func NewWebDriverWithRunningService(url string, options ...Option) *WebDriver {
+	apiWebDriver := api.NewWebDriverWithRunningService(url)
+	defaultOptions := config{Timeout: apiWebDriver.Timeout}.Merge(options)
+	apiWebDriver.Timeout = defaultOptions.Timeout
+	apiWebDriver.Debug = defaultOptions.Debug
+	apiWebDriver.HTTPClient = defaultOptions.HTTPClient
+	return &WebDriver{apiWebDriver, defaultOptions}
+}
+
 // NewWebDriver returns an instance of a WebDriver specified by
 // a templated URL and command. The URL should be the location of the
 // WebDriver Wire Protocol web service brought up by the command. The
@@ -43,6 +68,7 @@ func NewWebDriver(url string, command []string, options ...Option) *WebDriver {
 	apiWebDriver.HTTPClient = defaultOptions.HTTPClient
 	return &WebDriver{apiWebDriver, defaultOptions}
 }
+
 
 // NewPage returns a *Page that corresponds to a new WebDriver session.
 // Provided Options configure the page. For instance, to disable JavaScript:


### PR DESCRIPTION
On may want not to start appium from agouti but connect to an already running appium service (for example if it is located on a different host). This merge request allows this.