### PR TITLE
Added NewWithArgs to allow starting of the appium service with arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: go
-go_import_path: github.com/sclevine/agouti
+go_import_path: github.com/bradbev/agouti
 go:
- - 1.9.x
- - 1.10.x
+  - 1.9.x
+  - 1.10.x
 
 script:
- - go test -v ./...
+  - go test -v ./...
 
 install:
- - go get -d -t -v ./... && go build -v ./...
+  - go get -d -t -v ./... && go build -v ./...
 
 env:
- - HEADLESS_ONLY=true
+  - HEADLESS_ONLY=true

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@ Agouti
 ======
 
 [![Build Status](https://api.travis-ci.org/sclevine/agouti.png?branch=master)](http://travis-ci.org/sclevine/agouti)
-[![GoDoc](https://godoc.org/github.com/sclevine/agouti?status.svg)](https://godoc.org/github.com/sclevine/agouti)
+[![GoDoc](https://godoc.org/github.com/bradbev/agouti?status.svg)](https://godoc.org/github.com/bradbev/agouti)
 
 [![#agouti IRC on Freenode](https://kiwiirc.com/buttons/chat.freenode.net/agouti.png)](https://kiwiirc.com/client/chat.freenode.net/#agouti)
 
-Agouti is a library for writing browser-based acceptance tests in Google Go. It provides [Gomega](https://github.com/onsi/gomega) matchers and plays nicely with [Ginkgo](https://github.com/onsi/ginkgo) or [Spec](https://github.com/sclevine/spec). See [agouti.org](http://agouti.org) and the [GoDoc](https://godoc.org/github.com/sclevine/agouti) for documentation. Have questions? Check out the [Agouti mailing list](https://groups.google.com/d/forum/agouti) or the #agouti IRC channel on Freenode.
+Agouti is a library for writing browser-based acceptance tests in Google Go. It provides [Gomega](https://github.com/onsi/gomega) matchers and plays nicely with [Ginkgo](https://github.com/onsi/ginkgo) or [Spec](https://github.com/sclevine/spec). See [agouti.org](http://agouti.org) and the [GoDoc](https://godoc.org/github.com/bradbev/agouti) for documentation. Have questions? Check out the [Agouti mailing list](https://groups.google.com/d/forum/agouti) or the #agouti IRC channel on Freenode.
 
-The [integration tests](https://github.com/sclevine/agouti/blob/master/internal/integration/) are a great place to see everything in action and get started quickly!
+The [integration tests](https://github.com/bradbev/agouti/blob/master/internal/integration/) are a great place to see everything in action and get started quickly!
 
 <p align="center"><a href=http://agouti.org><img src="http://agouti.org/images/agouti_small.png" /></a></p>

--- a/api/element_test.go
+++ b/api/element_test.go
@@ -3,11 +3,11 @@ package api_test
 import (
 	"errors"
 
+	. "github.com/bradbev/agouti/api"
+	"github.com/bradbev/agouti/api/internal/mocks"
+	. "github.com/bradbev/agouti/internal/matchers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti/api"
-	"github.com/sclevine/agouti/api/internal/mocks"
-	. "github.com/sclevine/agouti/internal/matchers"
 )
 
 var _ = Describe("Element", func() {

--- a/api/internal/bus/client_test.go
+++ b/api/internal/bus/client_test.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 
+	. "github.com/bradbev/agouti/api/internal/bus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti/api/internal/bus"
 )
 
 var _ = Describe("Session", func() {

--- a/api/internal/bus/connect_test.go
+++ b/api/internal/bus/connect_test.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 
+	. "github.com/bradbev/agouti/api/internal/bus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti/api/internal/bus"
 )
 
 var _ = Describe(".Connect", func() {

--- a/api/internal/service/service_test.go
+++ b/api/internal/service/service_test.go
@@ -5,9 +5,9 @@ import (
 	"net/http/httptest"
 	"time"
 
+	. "github.com/bradbev/agouti/api/internal/service"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti/api/internal/service"
 )
 
 var _ = Describe("Service", func() {

--- a/api/mobile/session.go
+++ b/api/mobile/session.go
@@ -1,6 +1,6 @@
 package mobile
 
-import "github.com/sclevine/agouti/api"
+import "github.com/bradbev/agouti/api"
 
 type Session struct {
 	*api.Session

--- a/api/mobile/session_test.go
+++ b/api/mobile/session_test.go
@@ -3,10 +3,10 @@ package mobile
 import (
 	"errors"
 
+	"github.com/bradbev/agouti/api"
+	"github.com/bradbev/agouti/internal/mocks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/sclevine/agouti/api"
-	"github.com/sclevine/agouti/internal/mocks"
 )
 
 var _ = Describe("Bus", func() {

--- a/api/session.go
+++ b/api/session.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/sclevine/agouti/api/internal/bus"
+	"github.com/bradbev/agouti/api/internal/bus"
 )
 
 type Session struct {

--- a/api/session_test.go
+++ b/api/session_test.go
@@ -3,11 +3,11 @@ package api_test
 import (
 	"errors"
 
+	. "github.com/bradbev/agouti/api"
+	"github.com/bradbev/agouti/api/internal/mocks"
+	. "github.com/bradbev/agouti/internal/matchers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti/api"
-	"github.com/sclevine/agouti/api/internal/mocks"
-	. "github.com/sclevine/agouti/internal/matchers"
 )
 
 var _ = Describe("Session", func() {

--- a/api/webdriver.go
+++ b/api/webdriver.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/sclevine/agouti/api/internal/service"
+	"github.com/bradbev/agouti/api/internal/service"
 )
 
 type WebDriver struct {

--- a/api/webdriver_test.go
+++ b/api/webdriver_test.go
@@ -7,10 +7,10 @@ import (
 	"net/http/httptest"
 	"time"
 
+	. "github.com/bradbev/agouti/api"
+	"github.com/bradbev/agouti/api/internal/mocks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti/api"
-	"github.com/sclevine/agouti/api/internal/mocks"
 )
 
 type roundTripperFunc func(*http.Request) (*http.Response, error)

--- a/api/window_test.go
+++ b/api/window_test.go
@@ -3,10 +3,10 @@ package api_test
 import (
 	"errors"
 
+	. "github.com/bradbev/agouti/api"
+	"github.com/bradbev/agouti/api/internal/mocks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti/api"
-	"github.com/sclevine/agouti/api/internal/mocks"
 )
 
 var _ = Describe("Window", func() {

--- a/appium/device.go
+++ b/appium/device.go
@@ -3,9 +3,9 @@ package appium
 import (
 	"fmt"
 
-	"github.com/sclevine/agouti"
-	"github.com/sclevine/agouti/api/mobile"
-	"github.com/sclevine/agouti/internal/element"
+	"github.com/bradbev/agouti"
+	"github.com/bradbev/agouti/api/mobile"
+	"github.com/bradbev/agouti/internal/element"
 )
 
 type mobileSession interface {

--- a/appium/injector_test.go
+++ b/appium/injector_test.go
@@ -1,6 +1,6 @@
 package appium
 
-import "github.com/sclevine/agouti"
+import "github.com/bradbev/agouti"
 
 func NewTestDevice(session mobileSession) *Device {
 	return &Device{

--- a/appium/mock_session_test.go
+++ b/appium/mock_session_test.go
@@ -1,8 +1,8 @@
 package appium_test
 
 import (
-	"github.com/sclevine/agouti/api"
-	"github.com/sclevine/agouti/api/mobile"
+	"github.com/bradbev/agouti/api"
+	"github.com/bradbev/agouti/api/mobile"
 )
 
 type mockMobileSession struct {

--- a/appium/options.go
+++ b/appium/options.go
@@ -1,6 +1,6 @@
 package appium
 
-import "github.com/sclevine/agouti"
+import "github.com/bradbev/agouti"
 
 type Option func(*config)
 

--- a/appium/selection.go
+++ b/appium/selection.go
@@ -1,6 +1,6 @@
 package appium
 
-import "github.com/sclevine/agouti/internal/element"
+import "github.com/bradbev/agouti/internal/element"
 
 type elementRepository interface {
 	Get() ([]element.Element, error)

--- a/appium/touchaction.go
+++ b/appium/touchaction.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/sclevine/agouti"
-	"github.com/sclevine/agouti/api"
-	"github.com/sclevine/agouti/api/mobile"
-	"github.com/sclevine/agouti/internal/element"
-	"github.com/sclevine/agouti/internal/target"
+	"github.com/bradbev/agouti"
+	"github.com/bradbev/agouti/api"
+	"github.com/bradbev/agouti/api/mobile"
+	"github.com/bradbev/agouti/internal/element"
+	"github.com/bradbev/agouti/internal/target"
 )
 
 type TouchAction struct {

--- a/appium/touchaction_test.go
+++ b/appium/touchaction_test.go
@@ -1,6 +1,6 @@
 package appium_test
 
-import "github.com/sclevine/agouti/appium"
+import "github.com/bradbev/agouti/appium"
 
 var _ = Describe("TouchAction", func() {
 	session := &mockMobileSession{}

--- a/appium/webdriver.go
+++ b/appium/webdriver.go
@@ -12,9 +12,13 @@ type WebDriver struct {
 }
 
 func New(options ...Option) *WebDriver {
+	return NewWithArgs(nil, options...)
+}
+
+func NewWithArgs(args []string, options ...Option) *WebDriver {
 	newOptions := config{}.merge(options)
 	url := "http://{{.Address}}/wd/hub"
-	command := []string{"appium", "-p", "{{.Port}}"}
+	command := append([]string{"appium", "-p", "{{.Port}}"}, args...)
 	agoutiWebDriver := agouti.NewWebDriver(url, command, newOptions.agoutiOptions...)
 	return &WebDriver{agoutiWebDriver}
 }

--- a/appium/webdriver.go
+++ b/appium/webdriver.go
@@ -3,8 +3,8 @@ package appium
 import (
 	"fmt"
 
-	"github.com/sclevine/agouti"
-	"github.com/sclevine/agouti/api/mobile"
+	"github.com/bradbev/agouti"
+	"github.com/bradbev/agouti/api/mobile"
 )
 
 type WebDriver struct {

--- a/capabilities_test.go
+++ b/capabilities_test.go
@@ -1,9 +1,9 @@
 package agouti_test
 
 import (
+	. "github.com/bradbev/agouti"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti"
 )
 
 var _ = Describe("Capabilities", func() {

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/sclevine/agouti
+module github.com/bradbev/agouti

--- a/injector_test.go
+++ b/injector_test.go
@@ -1,6 +1,6 @@
 package agouti
 
-import "github.com/sclevine/agouti/internal/target"
+import "github.com/bradbev/agouti/internal/target"
 
 func NewTestSelection(session apiSession, elements elementRepository, firstSelector string) *Selection {
 	selector := target.Selector{Type: target.CSS, Value: firstSelector, Single: true}

--- a/internal/element/repository.go
+++ b/internal/element/repository.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/sclevine/agouti/api"
-	"github.com/sclevine/agouti/internal/target"
+	"github.com/bradbev/agouti/api"
+	"github.com/bradbev/agouti/internal/target"
 )
 
 type Repository struct {

--- a/internal/element/repository_test.go
+++ b/internal/element/repository_test.go
@@ -3,13 +3,13 @@ package element_test
 import (
 	"errors"
 
+	"github.com/bradbev/agouti/api"
+	. "github.com/bradbev/agouti/internal/element"
+	. "github.com/bradbev/agouti/internal/matchers"
+	"github.com/bradbev/agouti/internal/mocks"
+	"github.com/bradbev/agouti/internal/target"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/sclevine/agouti/api"
-	. "github.com/sclevine/agouti/internal/element"
-	. "github.com/sclevine/agouti/internal/matchers"
-	"github.com/sclevine/agouti/internal/mocks"
-	"github.com/sclevine/agouti/internal/target"
 )
 
 var _ = Describe("ElementRepository", func() {

--- a/internal/integration/integration_suite_test.go
+++ b/internal/integration/integration_suite_test.go
@@ -5,9 +5,9 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/bradbev/agouti"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/sclevine/agouti"
 )
 
 var (

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -3,7 +3,7 @@ package integration_test
 import (
 	. "github.com/onsi/ginkgo"
 
-	"github.com/sclevine/agouti"
+	"github.com/bradbev/agouti"
 )
 
 var _ = Describe("integration tests", func() {

--- a/internal/integration/mobile_test.go
+++ b/internal/integration/mobile_test.go
@@ -6,10 +6,10 @@ import (
 	"net/http/httptest"
 	"strings"
 
+	"github.com/bradbev/agouti"
+	. "github.com/bradbev/agouti/matchers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/sclevine/agouti"
-	. "github.com/sclevine/agouti/matchers"
 )
 
 func testMobile(browserName string, newPage pageFunc) {

--- a/internal/integration/page_test.go
+++ b/internal/integration/page_test.go
@@ -10,8 +10,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/sclevine/agouti"
-	. "github.com/sclevine/agouti/matchers"
+	"github.com/bradbev/agouti"
+	. "github.com/bradbev/agouti/matchers"
 )
 
 func testPage(browserName string, newPage pageFunc) {

--- a/internal/integration/selection_test.go
+++ b/internal/integration/selection_test.go
@@ -1,13 +1,14 @@
 package integration_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/sclevine/agouti"
-	. "github.com/sclevine/agouti/matchers"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+
+	"github.com/bradbev/agouti"
+	. "github.com/bradbev/agouti/matchers"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 func testSelection(browserName string, newPage pageFunc) {

--- a/internal/matchers/exactly_equal_test.go
+++ b/internal/matchers/exactly_equal_test.go
@@ -1,9 +1,9 @@
 package matchers_test
 
 import (
+	. "github.com/bradbev/agouti/internal/matchers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti/internal/matchers"
 )
 
 var _ = Describe("#ExactlyEqual", func() {

--- a/internal/mocks/element.go
+++ b/internal/mocks/element.go
@@ -1,6 +1,6 @@
 package mocks
 
-import "github.com/sclevine/agouti/api"
+import "github.com/bradbev/agouti/api"
 
 type Element struct {
 	GetElementCall struct {

--- a/internal/mocks/element_repository.go
+++ b/internal/mocks/element_repository.go
@@ -1,6 +1,6 @@
 package mocks
 
-import "github.com/sclevine/agouti/internal/element"
+import "github.com/bradbev/agouti/internal/element"
 
 type ElementRepository struct {
 	GetCall struct {

--- a/internal/mocks/session.go
+++ b/internal/mocks/session.go
@@ -3,7 +3,7 @@ package mocks
 import (
 	"encoding/json"
 
-	"github.com/sclevine/agouti/api"
+	"github.com/bradbev/agouti/api"
 )
 
 type Session struct {

--- a/internal/mocks/webdriver.go
+++ b/internal/mocks/webdriver.go
@@ -1,6 +1,6 @@
 package mocks
 
-import "github.com/sclevine/agouti/api"
+import "github.com/bradbev/agouti/api"
 
 type WebDriver struct {
 	OpenCall struct {

--- a/internal/target/selector.go
+++ b/internal/target/selector.go
@@ -3,7 +3,7 @@ package target
 import (
 	"fmt"
 
-	"github.com/sclevine/agouti/api"
+	"github.com/bradbev/agouti/api"
 )
 
 type Type string

--- a/internal/target/selector_test.go
+++ b/internal/target/selector_test.go
@@ -1,10 +1,10 @@
 package target_test
 
 import (
+	"github.com/bradbev/agouti/api"
+	. "github.com/bradbev/agouti/internal/target"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/sclevine/agouti/api"
-	. "github.com/sclevine/agouti/internal/target"
 )
 
 var _ = Describe("Selector", func() {

--- a/internal/target/selectors_test.go
+++ b/internal/target/selectors_test.go
@@ -1,9 +1,9 @@
 package target_test
 
 import (
+	. "github.com/bradbev/agouti/internal/target"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti/internal/target"
 )
 
 var _ = Describe("Selectors", func() {

--- a/matchers/internal/be_found_test.go
+++ b/matchers/internal/be_found_test.go
@@ -3,10 +3,10 @@ package internal_test
 import (
 	"errors"
 
+	. "github.com/bradbev/agouti/matchers/internal"
+	"github.com/bradbev/agouti/matchers/internal/mocks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti/matchers/internal"
-	"github.com/sclevine/agouti/matchers/internal/mocks"
 )
 
 var _ = Describe("BeFoundMatcher", func() {

--- a/matchers/internal/boolean_matcher_test.go
+++ b/matchers/internal/boolean_matcher_test.go
@@ -3,10 +3,10 @@ package internal_test
 import (
 	"errors"
 
+	. "github.com/bradbev/agouti/matchers/internal"
+	"github.com/bradbev/agouti/matchers/internal/mocks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti/matchers/internal"
-	"github.com/sclevine/agouti/matchers/internal/mocks"
 )
 
 var _ = Describe("BooleanMatcher", func() {

--- a/matchers/internal/colorparser/colorparser_test.go
+++ b/matchers/internal/colorparser/colorparser_test.go
@@ -1,9 +1,9 @@
 package colorparser_test
 
 import (
+	. "github.com/bradbev/agouti/matchers/internal/colorparser"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti/matchers/internal/colorparser"
 )
 
 var _ = Describe("Parsing CSS Colors", func() {

--- a/matchers/internal/equal_element_test.go
+++ b/matchers/internal/equal_element_test.go
@@ -2,11 +2,12 @@ package internal_test
 
 import (
 	"errors"
+
+	. "github.com/bradbev/agouti/internal/matchers"
+	. "github.com/bradbev/agouti/matchers/internal"
+	"github.com/bradbev/agouti/matchers/internal/mocks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti/internal/matchers"
-	. "github.com/sclevine/agouti/matchers/internal"
-	"github.com/sclevine/agouti/matchers/internal/mocks"
 )
 
 var _ = Describe("EqualElementMatcher", func() {

--- a/matchers/internal/have_attribute_test.go
+++ b/matchers/internal/have_attribute_test.go
@@ -3,10 +3,10 @@ package internal_test
 import (
 	"errors"
 
+	. "github.com/bradbev/agouti/matchers/internal"
+	"github.com/bradbev/agouti/matchers/internal/mocks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti/matchers/internal"
-	"github.com/sclevine/agouti/matchers/internal/mocks"
 )
 
 var _ = Describe("HaveAttributeMatcher", func() {

--- a/matchers/internal/have_css.go
+++ b/matchers/internal/have_css.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/bradbev/agouti/matchers/internal/colorparser"
 	"github.com/onsi/gomega/format"
-	"github.com/sclevine/agouti/matchers/internal/colorparser"
 )
 
 type HaveCSSMatcher struct {

--- a/matchers/internal/have_css_test.go
+++ b/matchers/internal/have_css_test.go
@@ -3,10 +3,10 @@ package internal_test
 import (
 	"errors"
 
+	. "github.com/bradbev/agouti/matchers/internal"
+	"github.com/bradbev/agouti/matchers/internal/mocks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti/matchers/internal"
-	"github.com/sclevine/agouti/matchers/internal/mocks"
 )
 
 var _ = Describe("HaveCSS", func() {

--- a/matchers/internal/log_matcher.go
+++ b/matchers/internal/log_matcher.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bradbev/agouti"
 	"github.com/onsi/gomega/format"
-	"github.com/sclevine/agouti"
 )
 
 type LogMatcher struct {

--- a/matchers/internal/log_matcher_test.go
+++ b/matchers/internal/log_matcher_test.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 	"time"
 
+	"github.com/bradbev/agouti"
+	. "github.com/bradbev/agouti/matchers/internal"
+	"github.com/bradbev/agouti/matchers/internal/mocks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/sclevine/agouti"
-	. "github.com/sclevine/agouti/matchers/internal"
-	"github.com/sclevine/agouti/matchers/internal/mocks"
 )
 
 var _ = Describe("LogMatcher", func() {

--- a/matchers/internal/match_text_test.go
+++ b/matchers/internal/match_text_test.go
@@ -3,10 +3,10 @@ package internal_test
 import (
 	"errors"
 
+	. "github.com/bradbev/agouti/matchers/internal"
+	"github.com/bradbev/agouti/matchers/internal/mocks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti/matchers/internal"
-	"github.com/sclevine/agouti/matchers/internal/mocks"
 )
 
 var _ = Describe("MatchTextMatcher", func() {

--- a/matchers/internal/mocks/page.go
+++ b/matchers/internal/mocks/page.go
@@ -1,6 +1,6 @@
 package mocks
 
-import "github.com/sclevine/agouti"
+import "github.com/bradbev/agouti"
 
 type Page struct {
 	TitleCall struct {

--- a/matchers/internal/value_matcher_test.go
+++ b/matchers/internal/value_matcher_test.go
@@ -3,10 +3,10 @@ package internal_test
 import (
 	"errors"
 
+	. "github.com/bradbev/agouti/matchers/internal"
+	"github.com/bradbev/agouti/matchers/internal/mocks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti/matchers/internal"
-	"github.com/sclevine/agouti/matchers/internal/mocks"
 )
 
 var _ = Describe("ValueMatcher", func() {

--- a/matchers/page_matchers.go
+++ b/matchers/page_matchers.go
@@ -1,8 +1,8 @@
 package matchers
 
 import (
+	"github.com/bradbev/agouti/matchers/internal"
 	"github.com/onsi/gomega/types"
-	"github.com/sclevine/agouti/matchers/internal"
 )
 
 // HaveTitle passes when the expected title is equivalent to the

--- a/matchers/page_matchers_test.go
+++ b/matchers/page_matchers_test.go
@@ -3,11 +3,11 @@ package matchers_test
 import (
 	"time"
 
+	"github.com/bradbev/agouti"
+	. "github.com/bradbev/agouti/matchers"
+	"github.com/bradbev/agouti/matchers/internal/mocks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/sclevine/agouti"
-	. "github.com/sclevine/agouti/matchers"
-	"github.com/sclevine/agouti/matchers/internal/mocks"
 )
 
 var _ = Describe("Page Matchers", func() {

--- a/matchers/selection_matchers.go
+++ b/matchers/selection_matchers.go
@@ -1,8 +1,8 @@
 package matchers
 
 import (
+	"github.com/bradbev/agouti/matchers/internal"
 	"github.com/onsi/gomega/types"
-	"github.com/sclevine/agouti/matchers/internal"
 )
 
 // HaveText passes when the expected text is equal to the actual element text.

--- a/matchers/selection_matchers_test.go
+++ b/matchers/selection_matchers_test.go
@@ -1,10 +1,10 @@
 package matchers_test
 
 import (
+	. "github.com/bradbev/agouti/matchers"
+	"github.com/bradbev/agouti/matchers/internal/mocks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti/matchers"
-	"github.com/sclevine/agouti/matchers/internal/mocks"
 )
 
 var _ = Describe("Selection Matchers", func() {

--- a/multiselection.go
+++ b/multiselection.go
@@ -1,6 +1,6 @@
 package agouti
 
-import "github.com/sclevine/agouti/internal/target"
+import "github.com/bradbev/agouti/internal/target"
 
 // A MultiSelection is a Selection that may be indexed using the At() method.
 // All Selection methods are available on a MultiSelection.

--- a/multiselection_test.go
+++ b/multiselection_test.go
@@ -1,11 +1,11 @@
 package agouti_test
 
 import (
+	. "github.com/bradbev/agouti"
+	"github.com/bradbev/agouti/api"
+	"github.com/bradbev/agouti/internal/mocks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti"
-	"github.com/sclevine/agouti/api"
-	"github.com/sclevine/agouti/internal/mocks"
 )
 
 var _ = Describe("MultiSelection", func() {

--- a/options_test.go
+++ b/options_test.go
@@ -4,10 +4,10 @@ import (
 	"net/http"
 	"time"
 
+	. "github.com/bradbev/agouti"
+	. "github.com/bradbev/agouti/internal/matchers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti"
-	. "github.com/sclevine/agouti/internal/matchers"
 )
 
 var _ = Describe("Options", func() {

--- a/page.go
+++ b/page.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sclevine/agouti/api"
+	"github.com/bradbev/agouti/api"
 )
 
 // A Page represents an open browser session. Pages may be created using the

--- a/page_test.go
+++ b/page_test.go
@@ -8,12 +8,12 @@ import (
 	"path/filepath"
 	"time"
 
+	. "github.com/bradbev/agouti"
+	"github.com/bradbev/agouti/api"
+	. "github.com/bradbev/agouti/internal/matchers"
+	"github.com/bradbev/agouti/internal/mocks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti"
-	"github.com/sclevine/agouti/api"
-	. "github.com/sclevine/agouti/internal/matchers"
-	"github.com/sclevine/agouti/internal/mocks"
 )
 
 var _ = Describe("Page", func() {

--- a/selectable.go
+++ b/selectable.go
@@ -1,9 +1,9 @@
 package agouti
 
 import (
-	"github.com/sclevine/agouti/api"
-	"github.com/sclevine/agouti/internal/element"
-	"github.com/sclevine/agouti/internal/target"
+	"github.com/bradbev/agouti/api"
+	"github.com/bradbev/agouti/internal/element"
+	"github.com/bradbev/agouti/internal/target"
 )
 
 type Selectors interface {

--- a/selectable_test.go
+++ b/selectable_test.go
@@ -1,11 +1,11 @@
 package agouti_test
 
 import (
+	. "github.com/bradbev/agouti"
+	"github.com/bradbev/agouti/api"
+	"github.com/bradbev/agouti/internal/mocks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti"
-	"github.com/sclevine/agouti/api"
-	"github.com/sclevine/agouti/internal/mocks"
 )
 
 var _ = Describe("Selectable", func() {

--- a/selection.go
+++ b/selection.go
@@ -3,9 +3,9 @@ package agouti
 import (
 	"fmt"
 
-	"github.com/sclevine/agouti/api"
-	"github.com/sclevine/agouti/internal/element"
-	"github.com/sclevine/agouti/internal/target"
+	"github.com/bradbev/agouti/api"
+	"github.com/bradbev/agouti/internal/element"
+	"github.com/bradbev/agouti/internal/target"
 )
 
 // Selection instances refer to a selection of elements.

--- a/selection_actions.go
+++ b/selection_actions.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/sclevine/agouti/api"
-	"github.com/sclevine/agouti/internal/element"
-	"github.com/sclevine/agouti/internal/target"
+	"github.com/bradbev/agouti/api"
+	"github.com/bradbev/agouti/internal/element"
+	"github.com/bradbev/agouti/internal/target"
 )
 
 type actionsFunc func(element.Element) error
@@ -50,12 +50,12 @@ func (s *Selection) DoubleClick() error {
 
 // Clear clears all fields the selection refers to.
 func (s *Selection) Clear() error {
-        return s.forEachElement(func(selectedElement element.Element) error {
-                if err := selectedElement.Clear(); err != nil {
-                        return fmt.Errorf("failed to clear %s: %s", s, err)
-                }
-                return nil
-        })
+	return s.forEachElement(func(selectedElement element.Element) error {
+		if err := selectedElement.Clear(); err != nil {
+			return fmt.Errorf("failed to clear %s: %s", s, err)
+		}
+		return nil
+	})
 }
 
 // Fill fills all of the fields the selection refers to with the provided text.

--- a/selection_actions_test.go
+++ b/selection_actions_test.go
@@ -4,13 +4,13 @@ import (
 	"errors"
 	"path/filepath"
 
+	. "github.com/bradbev/agouti"
+	"github.com/bradbev/agouti/api"
+	"github.com/bradbev/agouti/internal/element"
+	. "github.com/bradbev/agouti/internal/matchers"
+	"github.com/bradbev/agouti/internal/mocks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti"
-	"github.com/sclevine/agouti/api"
-	"github.com/sclevine/agouti/internal/element"
-	. "github.com/sclevine/agouti/internal/matchers"
-	"github.com/sclevine/agouti/internal/mocks"
 )
 
 var _ = Describe("Selection Actions", func() {

--- a/selection_frames.go
+++ b/selection_frames.go
@@ -3,7 +3,7 @@ package agouti
 import (
 	"fmt"
 
-	"github.com/sclevine/agouti/api"
+	"github.com/bradbev/agouti/api"
 )
 
 // SwitchToFrame focuses on the frame specified by the selection. All new and

--- a/selection_frames_test.go
+++ b/selection_frames_test.go
@@ -3,12 +3,12 @@ package agouti_test
 import (
 	"errors"
 
+	. "github.com/bradbev/agouti"
+	"github.com/bradbev/agouti/api"
+	. "github.com/bradbev/agouti/internal/matchers"
+	"github.com/bradbev/agouti/internal/mocks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti"
-	"github.com/sclevine/agouti/api"
-	. "github.com/sclevine/agouti/internal/matchers"
-	"github.com/sclevine/agouti/internal/mocks"
 )
 
 var _ = Describe("Selection Frames", func() {

--- a/selection_properties.go
+++ b/selection_properties.go
@@ -3,7 +3,7 @@ package agouti
 import (
 	"fmt"
 
-	"github.com/sclevine/agouti/internal/element"
+	"github.com/bradbev/agouti/internal/element"
 )
 
 // Text returns the entirety of the text content for exactly one element.

--- a/selection_properties_test.go
+++ b/selection_properties_test.go
@@ -3,13 +3,13 @@ package agouti_test
 import (
 	"errors"
 
+	. "github.com/bradbev/agouti"
+	"github.com/bradbev/agouti/api"
+	"github.com/bradbev/agouti/internal/element"
+	. "github.com/bradbev/agouti/internal/matchers"
+	"github.com/bradbev/agouti/internal/mocks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti"
-	"github.com/sclevine/agouti/api"
-	"github.com/sclevine/agouti/internal/element"
-	. "github.com/sclevine/agouti/internal/matchers"
-	"github.com/sclevine/agouti/internal/mocks"
 )
 
 var _ = Describe("Selection Properties", func() {

--- a/selection_test.go
+++ b/selection_test.go
@@ -3,13 +3,13 @@ package agouti_test
 import (
 	"errors"
 
+	. "github.com/bradbev/agouti"
+	"github.com/bradbev/agouti/api"
+	"github.com/bradbev/agouti/internal/element"
+	. "github.com/bradbev/agouti/internal/matchers"
+	"github.com/bradbev/agouti/internal/mocks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/sclevine/agouti"
-	"github.com/sclevine/agouti/api"
-	"github.com/sclevine/agouti/internal/element"
-	. "github.com/sclevine/agouti/internal/matchers"
-	"github.com/sclevine/agouti/internal/mocks"
 )
 
 var _ = Describe("Selection", func() {

--- a/webdriver.go
+++ b/webdriver.go
@@ -3,7 +3,7 @@ package agouti
 import (
 	"fmt"
 
-	"github.com/sclevine/agouti/api"
+	"github.com/bradbev/agouti/api"
 )
 
 // A WebDriver controls a WebDriver process. This struct embeds api.WebDriver,


### PR DESCRIPTION
My usecase was I wanted to start appium with "--relaxed-security", and possibly other options.  The other approach would have been to provide some sort of wrapping New for appium.WebDriver that accepted an agouti.WebDriver as an argument.