### PR TITLE
Added NewWithArgs to allow starting of the appium service with arguments

### DIFF
--- a/appium/webdriver.go
+++ b/appium/webdriver.go
@@ -12,9 +12,13 @@ type WebDriver struct {
 }
 
 func New(options ...Option) *WebDriver {
+	return NewWithArgs(nil, options...)
+}
+
+func NewWithArgs(args []string, options ...Option) *WebDriver {
 	newOptions := config{}.merge(options)
 	url := "http://{{.Address}}/wd/hub"
-	command := []string{"appium", "-p", "{{.Port}}"}
+	command := append([]string{"appium", "-p", "{{.Port}}"}, args...)
 	agoutiWebDriver := agouti.NewWebDriver(url, command, newOptions.agoutiOptions...)
 	return &WebDriver{agoutiWebDriver}
 }


### PR DESCRIPTION
My target use-case is starting the appium service with "--relaxed-security".  The other approach I considered was to allow more directly creating the appium.WebDriver struct so clients could provide an existing agouti.WebDriver.

Hopefully this PR is in an acceptable form - I've not done this often :)